### PR TITLE
fix SHA1 validation algorithm throws NullReferenceException

### DIFF
--- a/src/MachineKey.cs
+++ b/src/MachineKey.cs
@@ -114,7 +114,7 @@ namespace AspNetTicketBridge
                     decryptionAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(decryptionKey), primaryPurpose, specificPurposes);
 
                     // These KeyedHashAlgorithm instances are single-use; we wrap it in a 'using' block.
-                    using (KeyedHashAlgorithm validationAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as KeyedHashAlgorithm)
+                    using (HashAlgorithm validationAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as HashAlgorithm)
                     {
                         if (validationAlgorithm is KeyedHashAlgorithm keydValidationAlgorithm)
                         {

--- a/src/MachineKey.cs
+++ b/src/MachineKey.cs
@@ -61,10 +61,13 @@ namespace AspNetTicketBridge
                                 // memStream := IV || Enc(Kenc, IV, clearData)
 
                                 // These KeyedHashAlgorithm instances are single-use; we wrap it in a 'using' block.
-                                using (KeyedHashAlgorithm signingAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as KeyedHashAlgorithm)
+                                using (HashAlgorithm signingAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as HashAlgorithm)
                                 {
-                                    // Initialize the algorithm with the specified key
-                                    signingAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                                    // Initialize the algorithm with the specified key if it's KeyedHashAlgorithm
+                                    if (signingAlgorithm is KeyedHashAlgorithm keydSigningAlgorithm)
+                                    {
+                                        keydSigningAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                                    }
 
                                     // Compute the signature
                                     byte[] signature = signingAlgorithm.ComputeHash(memStream.GetBuffer(), 0, (int)memStream.Length);
@@ -113,7 +116,10 @@ namespace AspNetTicketBridge
                     // These KeyedHashAlgorithm instances are single-use; we wrap it in a 'using' block.
                     using (KeyedHashAlgorithm validationAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as KeyedHashAlgorithm)
                     {
-                        validationAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                        if (validationAlgorithm is KeyedHashAlgorithm keydValidationAlgorithm)
+                        {
+                            keydValidationAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                        }
 
                         int ivByteCount = decryptionAlgorithm.BlockSize / 8;
                         int signatureByteCount = validationAlgorithm.HashSize / 8;


### PR DESCRIPTION
Hi dmarlow, some validation algorithm doese not need validation key like SHA1, set the key property if it can converts to KeyedHashAlgorithm.